### PR TITLE
Evaluator improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,16 +17,12 @@ composer create-project jsdrupal/drupal-admin-ui-demo -s dev --prefer-dist
 ```sh
 cd drupal-admin-ui-demo/docroot
 php core/scripts/drupal install
-../bin/drush en -y jsonapi admin_ui_support
+../vendor/bin/drush en -y jsonapi admin_ui_support
 php core/scripts/drupal server
 ```
 
-Drupal will be opened up in your default browser.
-To access the new interface go to ```http://localhost:51569/vfancy```.
-
-Example URLs to visit:
+Drupal will be opened up in your default browser. Example URLs to visit:
 * ```/admin/people/permissions```
-
 
 # Updating
 ```sh

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "cweagans/composer-patches": "^1.6",
         "drupal-composer/drupal-scaffold": "^2.2",
         "drupal/core": "~8.6",
-        "drupal/jsonapi": "^1.13",
+        "drupal/jsonapi": "1.13.0",
         "oomphinc/composer-installers-extender": "^1.1",
         "webflo/drupal-finder": "^1.0.0",
         "webmozart/path-util": "^2.3",
@@ -52,8 +52,7 @@
         ],
         "post-update-cmd": [
             "@drupal-scaffold",
-            "DrupalProject\\composer\\ScriptHandler::createRequiredFiles",
-            "DrupalProject\\composer\\ScriptHandler::linkAdminSupportModule"
+            "DrupalProject\\composer\\ScriptHandler::createRequiredFiles"
         ]
     },
     "extra": {
@@ -72,12 +71,8 @@
         "enable-patching": true,
         "patches": {
             "drupal/core": {
-                "Provide a single command to install & run Drupal": "https://www.drupal.org/files/issues/2018-03-24/2911319-171.patch",
-                "Provide a script to install a Drupal testsite": "https://www.drupal.org/files/issues/2926633-115.patch"
+                "Provide a single command to install & run Drupal": "https://www.drupal.org/files/issues/2018-04-11/2911319-2-191.patch"
             }
         }
-    },
-    "config": {
-        "bin-dir": "bin/"
     }
 }


### PR DESCRIPTION
I wanted to try this out and had to make a few tweaks to get it running. One of them involves pinning to a dependency with a security vulnerability, so I understand that you may not want to merge this. Just wanted to document the discrepancies.

- Moved bin back to its default location so that it's compatible with the Drush Launcher.
- Removed reference to `http://localhost:51569/vfancy` since the port is variable and the `/vfancy` path actually didn't load anything for me.
- Pinned to jsonapi 1.13 because (among other things I think) drupal-admin-ui-support's extension of `RequestHandler` isn't compatible with the changes in https://www.drupal.org/node/2935370.
- Removed `linkAdminSupportModule` because it doesn't exist :) ...and I don't think any symlinks are necessary given that composer-installers puts everything where it needs to go.
- Updated patch for #2911319 (which no longer applied) and removed #2926633 (which was committed)
