### PR TITLE
Change working directory for install commands.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,8 +35,8 @@
     },
     "scripts": {
         "install": [
-            "php docroot/core/scripts/drupal install standard --no-interaction",
-            "vendor/bin/drush en -y jsonapi admin_ui_support"
+            "cd docroot && php core/scripts/drupal install standard --no-interaction",
+            "cd docroot && ../vendor/bin/drush en -y jsonapi admin_ui_support"
         ],
         "start": [
             "cd docroot && php core/scripts/drupal server"


### PR DESCRIPTION
Make sure that drupal console and drush are able to find the drupal instance.