### PR TITLE
add drupal/openaapi for drupal-admin-ui testing

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,8 @@
     },
     "require-dev": {
         "webflo/drupal-core-require-dev": "~8.6",
-        "drush/drush": "^9.2"
+        "drush/drush": "^9.2",
+        "drupal/openapi": "1.x-dev"
     },
     "minimum-stability": "dev",
     "prefer-stable": true,

--- a/composer.json
+++ b/composer.json
@@ -20,12 +20,12 @@
         "webflo/drupal-finder": "^1.0.0",
         "webmozart/path-util": "^2.3",
         "justafish/drupal-admin-ui": "dev-master",
-        "justafish/drupal-admin-ui-support": "dev-master"
+        "justafish/drupal-admin-ui-support": "dev-master",
+        "drupal/openapi": "1.x-dev"
     },
     "require-dev": {
         "webflo/drupal-core-require-dev": "~8.6",
-        "drush/drush": "^9.2",
-        "drupal/openapi": "1.x-dev"
+        "drush/drush": "^9.2"
     },
     "minimum-stability": "dev",
     "prefer-stable": true,


### PR DESCRIPTION
Adding OpenAPI as test dependency so that https://github.com/jsdrupal/drupal-admin-ui/pull/213 can use it for a new test.

This should also bring in `drupal/schemata` because it is a dependency of openapi.