### PR TITLE
Add patch for bundle jsonapi resource support in openapi

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -86,6 +86,9 @@
                 "Small inaccuracies for JSON API schemas": "https://www.drupal.org/files/issues/2018-04-28/2967572--schemata--multiple-minor-adjustments--3.patch",
                 "Take the field label into account for entity references": "https://www.drupal.org/files/issues/2018-07-20/2987199-2.patch"
             },
+            "drupal/openapi": {
+              "Does not work with JSONAPI resources that have no bundle": "https://www.drupal.org/files/issues/2018-07-18/2986679-2.patch",
+            },
             "drupal/core": {
             }
         }


### PR DESCRIPTION
Patch from: https://www.drupal.org/node/2986679

This will allow https://github.com/jsdrupal/drupal-admin-ui to use the latest release of OpenAPI and only apply the patches we need.